### PR TITLE
Implement metadata queries

### DIFF
--- a/check_api_constants.py
+++ b/check_api_constants.py
@@ -2,7 +2,8 @@
 
 import requests
 
-from census21api import (
+from census21api import CensusAPI
+from census21api.constants import (
     API_ROOT,
     AREA_TYPES_BY_POPULATION_TYPE,
     DIMENSIONS_BY_POPULATION_TYPE,
@@ -35,12 +36,11 @@ def _check_population_types():
 def _check_area_types_by_population_type():
     """Check that we have the area types for each population type."""
 
-    for pop_type in POPULATION_TYPES:
-        url = "/".join((API_ROOT, pop_type, "area-types?limit=100"))
-        response = requests.get(url, verify=True)
-        data = response.json()
+    api = CensusAPI()
 
-        available_area_types = set(item["id"] for item in data["items"])
+    for pop_type in POPULATION_TYPES:
+        metadata = api.query_area_type_metadata(pop_type)
+        available_area_types = set(metadata["id"])
         recorded_area_types = AREA_TYPES_BY_POPULATION_TYPE[pop_type]
 
         assert available_area_types == set(recorded_area_types), "\n".join(

--- a/src/census21api/wrapper.py
+++ b/src/census21api/wrapper.py
@@ -222,6 +222,37 @@ class CensusAPI:
 
         return metadata
 
+    def query_population_type_metadata(
+        self, population_type: str
+    ) -> Optional[pd.Series]:
+        """
+        Query the metadata for a population type.
+
+        Parameters
+        ----------
+        population_type : str
+            Population type to be queried.
+            See `census21api.POPULATION_TYPES`.
+
+        Returns
+        -------
+        metadata : pd.Series or None
+            Series with the population type metadata if the call
+            succeeds, and `None` if not.
+        """
+
+        url = "/".join((API_ROOT, population_type))
+        metadata_json = self.get(url)
+        metadata = None
+
+        if (
+            isinstance(metadata_json, dict)
+            and "population_type" in metadata_json
+        ):
+            metadata = pd.Series(metadata_json["population_type"])
+
+        return metadata
+
 
 def _extract_records_from_observations(
     observations: List[Dict[str, Any]], use_id: bool

--- a/src/census21api/wrapper.py
+++ b/src/census21api/wrapper.py
@@ -187,69 +187,6 @@ class CensusAPI:
 
             return data
 
-    def get_summary_by_dimensions(self) -> Dict[str, pd.DataFrame]:
-        """
-            builds and returns summaries of the data grouped by dimension
-
-        Returns:
-            a dict of both absolute counts for each dimension and proportions
-            normalised by the total.
-        """
-        if self._query_df is None:
-            print("No query data available to summarise.")
-            return None
-
-        self._groupby_dim_dict = {}
-        for dim in self._searched_dims:
-            groupby_ = self._query_df.groupby(dim)[["count"]].sum()
-            denom = groupby_.sum()
-            self._groupby_dim_dict[dim] = groupby_
-            self._groupby_dim_dict[f"{dim}_normalised"] = groupby_ / denom
-
-        return self._groupby_dim_dict
-
-    def get_summary_by_area(self) -> Dict[str, pd.DataFrame]:
-        """
-            builds and returns summaries of the data grouped by area
-
-        Returns:
-            a dict of both absolute counts for each area and proportions
-            normalised by the total.
-        """
-        if self._query_df is None:
-            print("No query data available to summarise.")
-            return None
-
-        self._groupby_area_dict = {}
-        groupby_ = self._query_df.groupby(self._searched_area)[["count"]].sum()
-        denom = groupby_.sum()
-        self._groupby_area_dict[self._searched_area] = groupby_
-        self._groupby_area_dict[f"{self._searched_area}_normalised"] = (
-            groupby_ / denom
-        )
-
-        return self._groupby_area_dict
-
-    def loop_through_variables(self, residence_code, region):
-        """
-        Collects data for all variable combinations relating to residence/region
-
-        Args:
-            residence_code: str = code relating to residence, eg. 'HH', 'UR'
-            region: str = regional code relating to region, eg. 'rgns'
-
-        Returns:
-            .csv file for all possible combinations
-        """
-        dims = list(DIMENSIONS_BY_POPULATION_TYPE[residence_code].values())
-        combos = [sorted(i) for i in itertools.product(dims, dims)]
-        trimmed_combos = sorted(list(map(list, set(map(frozenset, combos)))))
-        no_single_searches = [i for i in trimmed_combos if len(i) == 2]
-
-        for combination in no_single_searches:
-            stripped_string = ",".join(combination)
-            _ = self.query_api(residence_code, stripped_string, region)
-
 
 def _extract_records_from_observations(
     observations: List[Dict[str, Any]], use_id: bool

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -27,7 +27,7 @@ def st_table_queries(draw):
 
 
 @st.composite
-def st_observations(draw, max_nrows=10):
+def st_observations(draw, max_nrows=5):
     """Create a set of observations for a test."""
 
     _, area_type, dimensions = draw(st_table_queries())
@@ -96,3 +96,25 @@ def st_area_types_info_and_queries(draw):
     }
 
     return area_types_info, population_type, area_types
+
+
+@st.composite
+def st_area_type_areas_and_queries(draw):
+    """Create a set of area type areas and their query parameters."""
+
+    population_type = draw(st.sampled_from(POPULATION_TYPES))
+    area_type = draw(
+        st.sampled_from(AREA_TYPES_BY_POPULATION_TYPE[population_type])
+    )
+
+    num_items = draw(st.integers(min_value=1, max_value=5))
+    area_items = [
+        {
+            "id": draw(st.text()),
+            "label": draw(st.text()),
+            "area_type": area_type,
+        }
+        for _ in range(num_items)
+    ]
+
+    return area_items, population_type, area_type

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -64,3 +64,35 @@ def st_records_and_queries(draw, max_nrows=10):
         records.append(record)
 
     return records, population_type, area_type, dimensions
+
+
+@st.composite
+def st_area_types_info_and_queries(draw):
+    """Create the parameters and response for an area type query."""
+
+    population_type = draw(st.sampled_from(POPULATION_TYPES))
+
+    area_types_available = AREA_TYPES_BY_POPULATION_TYPE[population_type]
+    area_types = draw(
+        st.lists(
+            st.sampled_from(area_types_available),
+            min_size=0,
+            max_size=5,
+            unique=True,
+        )
+    )
+
+    area_types_info = {
+        "items": [
+            {
+                "id": area_type,
+                "label": st.text(),
+                "description": st.text(),
+                "total_count": st.integers(),
+                "hierarchy_order": st.integers(),
+            }
+            for area_type in area_types_available
+        ]
+    }
+
+    return area_types_info, population_type, area_types

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -67,6 +67,26 @@ def st_records_and_queries(draw, max_nrows=10):
 
 
 @st.composite
+def st_feature_queries(draw):
+    """Create a metadata query pack for testing."""
+
+    population_type = draw(st.sampled_from(POPULATION_TYPES))
+    endpoint = draw(st.sampled_from(("area-types", "dimensions")))
+
+    items_by_population_type = (
+        AREA_TYPES_BY_POPULATION_TYPE
+        if endpoint == "area-types"
+        else DIMENSIONS_BY_POPULATION_TYPE
+    )
+    possible_items = items_by_population_type[population_type]
+    items = draw(st.lists(st.sampled_from(possible_items), unique=True))
+
+    result = {"items": [{"id": item} for item in possible_items]}
+
+    return population_type, endpoint, items, result
+
+
+@st.composite
 def st_area_types_info_and_queries(draw):
     """Create the parameters and response for an area type query."""
 

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -68,7 +68,7 @@ def st_records_and_queries(draw, max_nrows=10):
 
 @st.composite
 def st_feature_queries(draw):
-    """Create a metadata query pack for testing."""
+    """Create a feature metadata query pack for testing."""
 
     population_type = draw(st.sampled_from(POPULATION_TYPES))
     endpoint = draw(st.sampled_from(("area-types", "dimensions")))
@@ -87,54 +87,22 @@ def st_feature_queries(draw):
 
 
 @st.composite
-def st_area_types_info_and_queries(draw):
-    """Create the parameters and response for an area type query."""
+def st_category_queries(draw):
+    """Create a category metadata query pack for testing."""
 
     population_type = draw(st.sampled_from(POPULATION_TYPES))
+    feature = draw(st.sampled_from(("area-types", "dimensions")))
+    endpoint = "areas" if feature == "area-types" else "categorisations"
 
-    area_types_available = AREA_TYPES_BY_POPULATION_TYPE[population_type]
-    area_types = draw(
-        st.lists(
-            st.sampled_from(area_types_available),
-            min_size=0,
-            max_size=5,
-            unique=True,
-        )
+    items_by_population_type = (
+        AREA_TYPES_BY_POPULATION_TYPE
+        if feature == "area-types"
+        else DIMENSIONS_BY_POPULATION_TYPE
     )
+    possible_items = items_by_population_type[population_type]
+    item = draw(st.sampled_from(possible_items))
 
-    area_types_info = {
-        "items": [
-            {
-                "id": area_type,
-                "label": st.text(),
-                "description": st.text(),
-                "total_count": st.integers(),
-                "hierarchy_order": st.integers(),
-            }
-            for area_type in area_types_available
-        ]
-    }
+    num_items = draw(st.integers(1, 5))
+    items = [{"item": st.text()} for _ in range(num_items)]
 
-    return area_types_info, population_type, area_types
-
-
-@st.composite
-def st_area_type_areas_and_queries(draw):
-    """Create a set of area type areas and their query parameters."""
-
-    population_type = draw(st.sampled_from(POPULATION_TYPES))
-    area_type = draw(
-        st.sampled_from(AREA_TYPES_BY_POPULATION_TYPE[population_type])
-    )
-
-    num_items = draw(st.integers(min_value=1, max_value=5))
-    area_items = [
-        {
-            "id": draw(st.text()),
-            "label": draw(st.text()),
-            "area_type": area_type,
-        }
-        for _ in range(num_items)
-    ]
-
-    return area_items, population_type, area_type
+    return population_type, feature, item, endpoint, items

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -258,6 +258,42 @@ def test_query_area_types_invalid(info_and_query, result):
 
 
 @given(st_area_type_areas_and_queries())
+def test_query_any_extra_area_items_no_extras(areas_and_query):
+    """Test the areas querist helper does nothing if there's no need."""
+
+    area_items, population_type, area_type = areas_and_query
+
+    api = CensusAPI()
+
+    url = "/".join((population_type, area_type))
+    areas_json = {"items": area_items, "count": 0, "total_count": 0}
+
+    items = api._query_any_extra_area_items(areas_json, url)
+
+    assert items == area_items
+
+
+@given(st_area_type_areas_and_queries())
+def test_query_any_extra_area_items_with_extras(areas_and_query):
+    """Test the areas querist helper makes more calls if needed."""
+
+    area_items, population_type, area_type = areas_and_query
+
+    api = CensusAPI()
+
+    url = "/".join((population_type, area_type))
+    areas_json = {"items": area_items.copy(), "count": 1, "total_count": 2}
+
+    with mock.patch("census21api.wrapper.CensusAPI.get") as get:
+        get.return_value = areas_json
+        items = api._query_any_extra_area_items(areas_json, url)
+
+    assert items == area_items * 2
+
+    get.assert_called_once_with(url + "&offset=1")
+
+
+@given(st_area_type_areas_and_queries())
 def test_query_area_type_areas_valid_one_shot(areas_and_query):
     """Test the areas querist can produce responses on a single call."""
 


### PR DESCRIPTION
With the aim of mapping all the endpoints for the API, this PR implements `query_{query-type}()` method for the following:

- [x] Population type metadata (`/{population-type}`)
- [x] Area types metadata (`/{population-type}/area-types`)
- [x] Area type areas (`/{population-type}/area-types/{area-type}/areas`)
- [x] Dimensions metadata (`/{population-type}/dimensions`)
- [x] Dimension categorisations (`/{population-type}/dimensions/{dimension}/categorisations`)